### PR TITLE
suggested changes for setting up the ORT-EP

### DIFF
--- a/alt_e2eshark/e2e_testing/backends.py
+++ b/alt_e2eshark/e2e_testing/backends.py
@@ -5,19 +5,17 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 import abc
 import onnxruntime as ort
-from typing import TypeVar, Union
+from typing import TypeVar
 from e2e_testing.storage import TestTensors
+from e2e_testing.framework import CompiledOutput, ModelArtifact
 
-CompiledArtifact = TypeVar("CompiledArtifact")
 Invoker = TypeVar("Invoker")
-
-CompiledOutput = Union[CompiledArtifact, ort.InferenceSession]
 
 
 class BackendBase(abc.ABC):
 
     @abc.abstractmethod
-    def compile(self, module) -> CompiledOutput:
+    def compile(self, module: ModelArtifact) -> CompiledOutput:
         """specifies how to compile an MLIR Module"""
 
     @abc.abstractmethod
@@ -69,27 +67,38 @@ class SimpleIREEBackend(BackendBase):
 
 class OnnxrtIreeEpBackend(BackendBase):
     '''This backend uses onnxrt iree-ep to compile and run onnx models for a specified hal_target_backend'''
-    def __init__(self, *, device="local-task", hal_target_backend="llvm-cpu"):
+    def __init__(self, *, device="local-task", hal_target_backend="llvm-cpu", providers=["IreeExecutionProvider"], inter_op_num_threads=None, intra_op_num_threads=None):
+        # may need the device and target_backend for the future (e.g., when IREE-EP has support for specifying)
         self.device = device
         self.hal_target_backend = hal_target_backend
-        self.providers=["IreeExecutionProvider"]
+
+        self.providers=providers
+        # TODO: have more session options be optionally configurable by init args
         self.sess_opt = ort.SessionOptions()
         self.sess_opt.execution_mode  = ort.ExecutionMode.ORT_PARALLEL
-        #  sess_opt.inter_op_num_threads = 14
-        #  sess_opt.intra_op_num_threads = 4
+        if inter_op_num_threads:
+            self.sess_opt.inter_op_num_threads = inter_op_num_threads
+        if intra_op_num_threads:
+            self.sess_opt.intra_op_num_threads = intra_op_num_threads
         #  sess_opt.log_verbosity_level = 0
 
-    def compile(self, module, *, save_to: str = None):
+    def compile(self, model, *, save_to: str = None):
         session = ort.InferenceSession(
-                   module.model,
+                   model,
                    self.sess_opt,
                    providers=self.providers,
                )
+        # can't save an onnx runtime session
         return session
 
-    def load(self, session, *, func_name=None):
+    def load(self, session: ort.InferenceSession, *, func_name=None):
         def func(x):
-            output = session.run(None, {input_name: x})
-            return TestTensors((output.to_host(),))
+            session_inputs = session.get_inputs()
+            session_outputs = session.get_outputs()
+            model_output = session.run(
+                [output.name for output in session_outputs],
+                {session_inputs[i].name: x[i] for i in range(len(session_inputs))},
+            )
+            return TestTensors(model_output)
 
         return func

--- a/alt_e2eshark/e2e_testing/test_configs/onnxconfig.py
+++ b/alt_e2eshark/e2e_testing/test_configs/onnxconfig.py
@@ -8,9 +8,11 @@ from torch_mlir.extras import onnx_importer
 from torch_mlir.dialects import torch as torch_d
 from torch_mlir.ir import Context
 from e2e_testing.backends import BackendBase
-from e2e_testing.framework import TestConfig, OnnxModelInfo
+from e2e_testing.framework import TestConfig, OnnxModelInfo, Module, CompiledArtifact
+from e2e_testing.storage import TestTensors
 from torch_mlir.passmanager import PassManager
 from typing import Tuple
+from onnxruntime import InferenceSession
 
 REDUCE_TO_LINALG_PIPELINE = [
     "torch-lower-to-backend-contract",
@@ -25,23 +27,25 @@ class OnnxEpTestConfig(TestConfig):
         self.log_dir = log_dir
         self.backend = backend
 
-    def infer_shape(self, model_info: OnnxModelInfo, *, save_to: str = None):
+    def import_model(self, model_info: OnnxModelInfo, *, save_to: str = None) -> Tuple[onnx.ModelProto, None]:
         model = onnx.load(model_info.model)
         if model_info.opset_version:
             model = onnx.version_converter.convert_version(
                 model, model_info.opset_version
             )
+        # don't save the model, since it already exists in the log directory.
+        return model, None
+    
+    def preprocess_model(self, model: onnx.ModelProto, *, save_to: str) -> onnx.ModelProto:
         shaped_model = onnx.shape_inference.infer_shapes(model, data_prop=True)
-        # log imported IR
         if save_to:
-            onnx.save(shaped_model, save_to + "model.onnx")
-        model_info.model = shaped_model
-        return model_info
+            onnx.save(shaped_model, save_to + "inferred_model.onnx")
+        return shaped_model
 
-    def compile(self, model_info, *, save_to: str = None):
-        return self.backend.compile(model_info, save_to=save_to)
+    def compile(self, model: onnx.ModelProto, *, save_to: str = None) -> InferenceSession:
+        return self.backend.compile(model, save_to=save_to)
 
-    def run(self, session, inputs):
+    def run(self, session: InferenceSession, inputs: TestTensors) -> TestTensors:
         func = self.backend.load(session)
         return func(inputs)
 
@@ -59,7 +63,7 @@ class OnnxTestConfig(TestConfig):
         else:
             self.pass_pipeline = None
 
-    def mlir_import(self, model_info: OnnxModelInfo, *, save_to: str = None):
+    def import_model(self, model_info: OnnxModelInfo, *, save_to: str = None) -> Tuple[Module, str]:
         model = onnx.load(model_info.model)
         if model_info.opset_version:
             model = onnx.version_converter.convert_version(
@@ -81,7 +85,7 @@ class OnnxTestConfig(TestConfig):
                 f.write(str(m))
         return m, func_name
 
-    def apply_torch_mlir_passes(self, mlir_module, *, save_to: str = None):
+    def preprocess_model(self, mlir_module: Module, *, save_to: str = None) -> Module:
         # if the pass pipeline is empty, return the original module
         if not self.pass_pipeline:
             return mlir_module
@@ -102,9 +106,9 @@ class OnnxTestConfig(TestConfig):
                     f.write(str(mlir_module))
         return mlir_module
 
-    def compile(self, mlir_module, *, save_to: str = None):
+    def compile(self, mlir_module: Module, *, save_to: str = None) -> CompiledArtifact:
         return self.backend.compile(mlir_module, save_to=save_to)
 
-    def run(self, artifact, inputs, *, func_name="main"):
+    def run(self, artifact: CompiledArtifact, inputs: TestTensors, *, func_name="main") -> TestTensors:
         func = self.backend.load(artifact, func_name=func_name)
         return func(inputs)

--- a/alt_e2eshark/e2e_testing/test_configs/onnxconfig.py
+++ b/alt_e2eshark/e2e_testing/test_configs/onnxconfig.py
@@ -45,7 +45,7 @@ class OnnxEpTestConfig(TestConfig):
     def compile(self, model: onnx.ModelProto, *, save_to: str = None) -> InferenceSession:
         return self.backend.compile(model, save_to=save_to)
 
-    def run(self, session: InferenceSession, inputs: TestTensors) -> TestTensors:
+    def run(self, session: InferenceSession, inputs: TestTensors, *, func_name=None) -> TestTensors:
         func = self.backend.load(session)
         return func(inputs)
 

--- a/alt_e2eshark/run.py
+++ b/alt_e2eshark/run.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import argparse
 import re
 import logging
+from typing import List
 
 # append alt_e2eshark dir to path to allow importing without explicit pythonpath management
 TEST_DIR = str(Path(__file__).parent)
@@ -27,25 +28,15 @@ from e2e_testing.test_configs.onnxconfig import (
 # import backends
 from e2e_testing.backends import SimpleIREEBackend, OnnxrtIreeEpBackend
 
-IREE_STAGES = [
+ALL_STAGES = [
     "setup",
     "native_inference",
-    "mlir_import",
-    "torch_mlir",
+    "import_model",
+    "preprocessing",
     "compilation",
     "compiled_inference",
-    "post-processing",
+    "postprocessing",
 ]
-
-ORT_STAGES = [
-    "setup",
-    "shape_infer",
-    "native_inference",
-    "compilation",
-    "compiled_inference",
-    "post-processing",
-]
-
 
 def get_tests(groups, test_filter):
     """imports tests based on groups and test_filter specification"""
@@ -75,29 +66,27 @@ def get_tests(groups, test_filter):
 
 def main(args):
     """Sets up config and test list based on CL args, then runs the tests"""
+    # TODO: allow for no-run/mark xfails
+    # TODO: add better logging setup
+
     # setup config
-    if args.framework == "onnx":
+    if args.mode == "onnx-iree":
         pipeline = REDUCE_TO_LINALG_PIPELINE if args.torchtolinalg else []
         config = OnnxTestConfig(
             str(TEST_DIR), SimpleIREEBackend(device=args.device, hal_target_backend=args.backend), pipeline
         )
-
-        # get test list
-        test_list = get_tests(args.groups, args.test_filter)
-
-        # TODO: allow for no-run/mark xfails
-        # TODO: add better logging setup
-
-        stages = IREE_STAGES
-
-    elif args.framework == "onnx-ep":
+    elif args.mode == "onnx-ep":
+        # TODO: allow specifying provider explicitly from cl args.
         config = OnnxEpTestConfig(
             str(TEST_DIR), OnnxrtIreeEpBackend(device=args.device, hal_target_backend=args.backend))
-        # get test list
-        test_list = get_tests(args.groups, args.test_filter)
-        stages = ORT_STAGES
     else:
         raise NotImplementedError("only onnx frontend supported now")
+
+    # get test list
+    test_list = get_tests(args.groups, args.test_filter)
+
+    #setup test stages
+    stages = ALL_STAGES
 
     if args.stages:
         stages = args.stages
@@ -117,7 +106,7 @@ def main(args):
 
 
 def run_tests(
-    test_list, config, dir_name, cache_dir_name, no_artifacts, verbose, stages, load_inputs
+    test_list: List[Test], config: TestConfig, dir_name: str, cache_dir_name: str, no_artifacts: bool, verbose: bool, stages: List[str], load_inputs: bool
 ):
     """runs tests in test_list based on config"""
     # TODO: multi-process
@@ -160,19 +149,14 @@ def run_tests(
             # set up test
             curr_stage = "setup"
             if curr_stage in stages:
-                # build an instance of the test class
+                # build an instance of the test info class
                 inst = t.model_constructor(t.unique_name, log_dir, cache_dir)
-                # generate inputs from the test instance
+                # generate inputs from the test info instance
                 if load_inputs:
                     inputs = inst.load_inputs(log_dir)
                 else:
                     inputs = inst.construct_inputs()
                     inputs.save_to(log_dir + "input")
-
-            # run native inference
-            curr_stage = "shape_infer"
-            if curr_stage in stages:
-                inst = config.infer_shape(inst)
 
             # run native inference
             curr_stage = "native_inference"
@@ -181,33 +165,33 @@ def run_tests(
                 golden_outputs_raw.save_to(log_dir + "golden_output")
 
             # generate mlir from the instance using the config
-            curr_stage = "mlir_import"
+            curr_stage = "import_model"
             if curr_stage in stages:
                 artifact_save_to = None if no_artifacts else log_dir
-                mlir_module, func_name = config.mlir_import(
+                model_artifact, func_name = config.import_model(
                     inst, save_to=artifact_save_to
                 )
 
-            # apply torch-mlir lowerings
-            curr_stage = "torch_mlir"
+            # apply config-specific preprocessing to the ModelArtifact
+            curr_stage = "preprocessing"
             if curr_stage in stages:
-                mlir_module = config.apply_torch_mlir_passes(
-                    mlir_module, save_to=artifact_save_to
+                model_artifact = config.preprocess_model(
+                    model_artifact, save_to=artifact_save_to
                 )
 
             # compile mlir_module using config (calls backend compile)
             curr_stage = "compilation"
             if curr_stage in stages:
-                buffer = config.compile(mlir_module, save_to=artifact_save_to)
+                compiled_artifact = config.compile(model_artifact, save_to=artifact_save_to)
 
             # run inference with the compiled module
             curr_stage = "compiled_inference"
             if curr_stage in stages:
-                outputs_raw = config.run(buffer, inputs, func_name=func_name)
+                outputs_raw = config.run(compiled_artifact, inputs, func_name=func_name)
                 outputs_raw.save_to(log_dir + "output")
 
             # apply model-specific post-processing:
-            curr_stage = "post-processing"
+            curr_stage = "postprocessing"
             if curr_stage in stages:
                 golden_outputs = inst.apply_postprocessing(golden_outputs_raw)
                 outputs = inst.apply_postprocessing(outputs_raw)
@@ -291,37 +275,44 @@ def _get_argparse():
         default="llvm-cpu",
         help="specifies the iree-hal-target-backend for compile phase",
     )
+    # parser.add_argument(
+    #     "-f",
+    #     "--framework",
+    #     choices=["pytorch", "onnx", "tensorflow"],
+    #     default="onnx",
+    #     help="Run tests for given framework(s)",
+    # )
     parser.add_argument(
-        "-f",
-        "--framework",
-        choices=["pytorch", "onnx", "onnx-ep", "tensorflow"],
-        default="onnx",
-        help="Run tests for given framework(s)",
+        "-m",
+        "--mode",
+        choices=["onnx-iree", "ort-ep"],
+        default="onnx-iree",
+        help="onnx-iree=onnx->torch-mlir->IREE, ort=onnx->run with custom ORT EP inference session",
     )
     parser.add_argument(
         "--torchtolinalg",
         action="store_true",
         default=False,
-        help="Have torch-mlir-opt to produce linalg instead of torch mlir and pass that to iree-compile",
+        help="for mode = onnx-iree: Have torch-mlir-opt convert to linalg before passing to iree-compile",
     )
-    parser.add_argument(
-        "--torchmlirimport",
-        choices=["compile", "fximport"],
-        default="fximport",
-        help="Use torch_mlir.torchscript.compile, or Fx importer",
-    )
+    # parser.add_argument(
+    #     "--torchmlirimport",
+    #     choices=["compile", "fximport"],
+    #     default="fximport",
+    #     help="Use torch_mlir.torchscript.compile, or Fx importer",
+    # )
 
     # arguments for customizing test-stages:
     parser.add_argument(
         "--stages",
         nargs="*",
-        choices=IREE_STAGES,
+        choices=ALL_STAGES,
         help="Manually specify which test stages to run.",
     )
     parser.add_argument(
         "--skip-stages",
         nargs="*",
-        choices=IREE_STAGES,
+        choices=ALL_STAGES,
         help="Manually specify which test stages to skip.",
     )
     parser.add_argument(
@@ -330,18 +321,6 @@ def _get_argparse():
         default=False,
         help="If true, will try to load inputs from bin files.",
     )
-    # parser.add_argument(
-    #     "--runfrom",
-    #     choices=["model-run", "torch-mlir", "iree-compile"],
-    #     default="model-run",
-    #     help="Start from model-run, or torch MLIR, or IREE compiled artefact",
-    # )
-    # parser.add_argument(
-    #     "--runupto",
-    #     choices=["torch-mlir", "iree-compile", "inference"],
-    #     default="inference",
-    #     help="Run upto torch MLIR generation, IREE compilation, or inference",
-    # )
 
     # test-list filtering arguments:
     parser.add_argument(
@@ -356,10 +335,10 @@ def _get_argparse():
         "--test-filter",
         help="Run given specific test(s) only",
     )
-    parser.add_argument(
-        "--testsfile",
-        help="A file with lists of tests (starting with framework name) to run",
-    )
+    # parser.add_argument(
+    #     "--testsfile",
+    #     help="A file with lists of tests (starting with framework name) to run",
+    # )
 
     # test tolerance
     parser.add_argument(
@@ -407,13 +386,6 @@ def _get_argparse():
     #     type=int,
     #     default=4,
     #     help="Number of parallel processes to use per machine for running tests",
-    # )
-    # parser.add_argument(
-    #     "-m",
-    #     "--mode",
-    #     choices=["direct", "turbine", "onnx", "ort", "vaiml"],
-    #     default="onnx",
-    #     help="direct=Fx/TS->torch-mlir, turbine=aot-export->torch-mlir, onnx=exportonnx-to-torch-mlir, ort=exportonnx-to-ortep",
     # )
     # parser.add_argument(
     #     "--norun",

--- a/alt_e2eshark/run.py
+++ b/alt_e2eshark/run.py
@@ -75,7 +75,7 @@ def main(args):
         config = OnnxTestConfig(
             str(TEST_DIR), SimpleIREEBackend(device=args.device, hal_target_backend=args.backend), pipeline
         )
-    elif args.mode == "onnx-ep":
+    elif args.mode == "ort-ep":
         # TODO: allow specifying provider explicitly from cl args.
         config = OnnxEpTestConfig(
             str(TEST_DIR), OnnxrtIreeEpBackend(device=args.device, hal_target_backend=args.backend))


### PR DESCRIPTION
Since I had lots of comments, I decided to just push a PR instead. 

The core of your PR was good. My biggest overall change here is to make the stage names more generic, so we can eliminate the need for divergent stages per mode. The rest of this is mostly just cleaning the base code up a bit so it will be easier to read, and easier for another config to get added in the future.

I also thought it would make more sense for the `onnx.ModelProto` to be the `ModelArtifact` for the ORTEP config. I added a bunch of type hints so that it was more clear what the changes made here are really doing. 

Let me know what you think of my suggestions here. You can test it out with: 

```
python run.py --cachedir="" -v -t add -m ort-ep
```